### PR TITLE
Ability to filter by dates

### DIFF
--- a/sections/filtering.md
+++ b/sections/filtering.md
@@ -81,6 +81,8 @@ Examples of `where` conditions (not urlencoded for clarity):
 * `name like Sample`
 * `name="Sample Project"`
 * `price_per_hour>50`
+* `created_on<=2014-01-01T12:00:00Z`
+* `updated_on>2014-02-01T14:00:00Z`
 
 
 


### PR DESCRIPTION
It would be very useful if I could filter the tasks of a project by date. This way the response body will become increasingly smaller, for a project with 10k tasks for example.

It would be perfect if the results can be sorted `ASC` or `DESC`.
