### PR TITLE
Fixing ## headings on README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Paymo is a [project management software](https://www.paymoapp.com/project-manage
 
 This is the official Paymo API.
 
-#Paymo API
+# Paymo API
 
 * [Making a request](#make-request)
 * [Authentication](#authentication)
@@ -21,7 +21,7 @@ The Paymo is a [RESTful](http://en.wikipedia.org/wiki/Representational_State_Tra
 Accepted request types (HTTP verbs) are: GET, POST, PUT, DELETE.
 
 <a name="make-request"></a>
-##Making a request
+## Making a request
 
 The API base URL is `https://app.paymoapp.com/api/`. It is **SSL only**. There is no way to use the API over unsecure http:// protocol.
 
@@ -45,19 +45,19 @@ curl -u email:password
 See sample [code examples](sections/sample_code.md) on how to make a request to the API.
 
 <a name="authentication"></a>
-##Authentication
+## Authentication
 
 Read the [authentication guide](https://github.com/paymoapp/api/blob/master/sections/authentication.md) for more details.
 
 <a name="content-types"></a>
-##Request and response content types
+## Request and response content types
 
 Paymo API supports JSON as well as XML for data serialization, as well as specific types such as PDF, XLS for reports, invoices, estimates.
 
 Read more about [content types](sections/content_types.md).
 
 <a name="response-codes"></a>
-##Response codes and error handling
+## Response codes and error handling
 
 The Paymo API will return a 2xx status code for successful requests. The 4xx error means an error on the user side. And the 5xx errors are returned when the Paymo service is having trouble processing your request.
 
@@ -107,20 +107,20 @@ If you exceed the rate limit, you'll get a [429 Too Many Requests](http://tools.
 For a sample and an explanation of each endpoint object, see individual endpoint pages.
 
 <a name="filtering"></a>
-##Filtering
+## Filtering
 
 If you want to filter the response of listings, you can do so by supplying the `where` parameter in the request URL.
 
 Read more about [response filtering](sections/filtering.md)
 
 <a name="includes"></a>
-##Including related content
+## Including related content
 
 If you want a response to include additional information about an object, you can do so by supplying the `include` or `partial_include` parameters in the request URL.
 
 Read more about [additional includes](sections/includes.md)
 
-##Help us make it better
+## Help us make it better
 
 Please tell us how we can make the API better. If you have a specific feature request or if you found a bug, please use GitHub issues. Fork these docs and send a pull request with improvements.
 


### PR DESCRIPTION
Added spaces to the ## headings, that made that the text wasn't rendered as desired.