### PR TITLE
Explain that WHERE queries require UNIX Timestamp

### DIFF
--- a/sections/datetime.md
+++ b/sections/datetime.md
@@ -9,3 +9,8 @@ Examples:
 * `2015-01-17T10:23:02-08:00` for representing a date combined with time in another timezone
 
 For responses by Paymo API containing datetime values, the values will be in UTC.
+
+IMPORTANT: When sending requests with a filter on a date time value for parameters that use dates or times you should use the numeric unix timestamp value for the date field (converting to UNIX timestamp would be handled by the programming language you are using): 
+
+Example: To get all items created after 2020-03-11T19:20:41Z
+* ?where=created_on>=1583954441


### PR DESCRIPTION
When sending queries, the string representation of the date/datetime is not converted by Paymo. It must be sent as an integer in the WHERE query variable.