### PR TITLE
Child include for threads is "comments"

### DIFF
--- a/sections/comments.md
+++ b/sections/comments.md
@@ -228,4 +228,4 @@ Object type|Include key|Relationship
 [Discussion](discussion.md) | discussion | parent
 [Task](tasks.md) | task | parent
 [Files](files.md) | file | parent
-[Comment](comments.md) | comment | child
+[Comment](comments.md) | comments | child


### PR DESCRIPTION
Incorrectly said "comment" for child include list, should be plural. Singular version throws 500 error as written.